### PR TITLE
 Add menu options for 'Visualize Motion Values' and 'Motion Shift' regs (set A) of VIP Deinterlacer II

### DIFF
--- a/sw_common/sys_controller/inc/avconfig.h
+++ b/sw_common/sys_controller/inc/avconfig.h
@@ -148,6 +148,9 @@ typedef struct {
     uint8_t scl_aspect;
     uint8_t scl_alg;
     uint8_t scl_dil_alg;
+#ifdef VIP
+    uint8_t scl_dil_motion_shift;
+#endif
     uint8_t sm_scl_240p_288p;
     uint8_t sm_scl_480i_576i;
     uint8_t sm_scl_480p;

--- a/sw_common/sys_controller/src/avconfig.c
+++ b/sw_common/sys_controller/src/avconfig.c
@@ -46,6 +46,9 @@ const avconfig_t tc_default = {
     .scl_out_mode = 4,
     .scl_alg = 1,
     .scl_dil_alg = 2,
+#ifdef VIP
+    .scl_dil_motion_shift = 3,
+#endif
     .sm_scl_480p = 1,
 #ifndef DExx_FW
     .audio_src_map = {AUD_AV1_ANALOG, AUD_AV2_ANALOG, AUD_AV3_ANALOG, AUD_AV4_DIGITAL},
@@ -102,7 +105,11 @@ status_t update_avconfig() {
         (tc.nir_even_offset != cc.nir_even_offset) ||
         (tc.ypbpr_cs != cc.ypbpr_cs) ||
         (tc.scl_alg != cc.scl_alg) ||
-        (tc.scl_dil_alg != cc.scl_dil_alg))
+        (tc.scl_dil_alg != cc.scl_dil_alg)
+#ifdef VIP
+        || (tc.scl_dil_motion_shift != cc.scl_dil_motion_shift)
+#endif
+       )
         status = (status < SC_CONFIG_CHANGE) ? SC_CONFIG_CHANGE : status;
 
     if ((tc.pm_240p != cc.pm_240p) ||

--- a/sw_common/sys_controller/src/menu.c
+++ b/sw_common/sys_controller/src/menu.c
@@ -104,7 +104,11 @@ static const char *scl_out_mode_desc[] = { "720x480 (60Hz)", "720x576 (50Hz)", "
 static const char *scl_framelock_desc[] = { "On", "Off (50Hz)", "Off (60Hz)" };
 static const char *scl_aspect_desc[] = { "4:3", "16:9", "8:7", "1:1 source PAR", "Full" };
 static const char *scl_alg_desc[] = { "Nearest", "Lanczos3" };
+#ifdef DEBUG
+static const char *scl_dil_alg_desc[] = { "Bob", "Weave", "Motion adaptive", "Visualize motion" };
+#else
 static const char *scl_dil_alg_desc[] = { "Bob", "Weave", "Motion adaptive" };
+#endif
 static const char *sm_scl_240p_288p_desc[] = { "Generic", "SNES 256col", "SNES 512col", "MD 256col", "MD 320col", "PSX 256col", "PSX 320col", "PSX 384col", "PSX 512col", "PSX 640col", "N64 320col", "N64 640col" };
 static const char *sm_scl_480i_576i_desc[] = { "Generic", "DTV 480i/576i" };
 static const char *sm_scl_480p_desc[] = { "Generic", "DTV 480p", "VESA 640x480@60" };
@@ -242,6 +246,9 @@ MENU(menu_scaler, P99_PROTECT({
     { "Aspect ratio",                           OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_aspect,      OPT_WRAP, SETTING_ITEM(scl_aspect_desc) } } },
     { "Scaling algorithm",                      OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_alg,         OPT_WRAP, SETTING_ITEM(scl_alg_desc) } } },
     { "Deinterlace mode",                       OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_dil_alg,     OPT_WRAP, SETTING_ITEM(scl_dil_alg_desc) } } },
+#if defined(VIP) && defined(DEBUG)
+    { "Motion shift",                           OPT_AVCONFIG_NUMVALUE, { .num = { &tc.scl_dil_motion_shift,     OPT_NOWRAP, 0, 7, value_disp } } },
+#endif
     { LNG("240p/288p mode","240p/288pﾓｰﾄﾞ"),    OPT_AVCONFIG_SELECTION, { .sel = { &tc.sm_scl_240p_288p, OPT_WRAP, SETTING_ITEM(sm_scl_240p_288p_desc) } } },
     { LNG("480i/576i mode","480i/576iﾓｰﾄﾞ"),    OPT_AVCONFIG_SELECTION, { .sel = { &tc.sm_scl_480i_576i, OPT_WRAP, SETTING_ITEM(sm_scl_480i_576i_desc) } } },
     { LNG("480p mode","480pﾓｰﾄﾞ"),              OPT_AVCONFIG_SELECTION, { .sel = { &tc.sm_scl_480p,      OPT_WRAP, SETTING_ITEM(sm_scl_480p_desc) } } },

--- a/sw_common/sys_controller/src/sys_controller.c
+++ b/sw_common/sys_controller/src/sys_controller.c
@@ -326,9 +326,15 @@ void update_sc_config(mode_data_t *vm_in, mode_data_t *vm_out, vm_mult_config_t 
         vip_dli->mode = (1<<1);
     } else if (avconfig->scl_dil_alg == 1) {
         vip_dli->mode = (1<<2);
+    } else if (avconfig->scl_dil_alg == 3) {
+        vip_dli->mode = (1<<0);
     } else {
         vip_dli->mode = 0;
     }
+
+#ifdef DEBUG
+    vip_dli->motion_shift = avconfig->scl_dil_motion_shift;
+#endif
 
     if (avconfig->scl_alg == 0) {
         vip_scl_nn->width = vm_conf->x_size;


### PR DESCRIPTION
Intel VIP user guide recomments that the `Motion Shift` and `Motion Scale` registers are tweaked with the help of the `Visualize Motion Values` feature (see section 15.13.2 or description of the respective registers).

According to the guide, the `Motion Scale` register is only available with register set B, which is in place only if Deinterlacer II is configured with video-over-film mode enabled. To enable video-over-film mode, the `Cadence detection and reverse pulldown` configuration parameter would have to be enabled (which is disabled currently), and then the `Cadence detection algorithm` parameter would have to be set to `3:2 & 2:2 detector with video over film` (which is the default). This would in turn necessitate buffering 1 field prior to output and setting the deinterlacing algorithm to `Motion Adaptive High Quality`.

So before going all-out and performing these changes to the compile-time configuration, we only make the `Motion Shift`register accessible for now, and see if we can achieve any improvement this way already.