### PR TITLE
sw: allow for VIP Dil II with register set B

### DIFF
--- a/board/de10-nano/software/sys_controller/inc/sysconfig.h
+++ b/board/de10-nano/software/sys_controller/inc/sysconfig.h
@@ -7,6 +7,14 @@
 #define INC_ADV7513
 #define VIP
 
+#if ALT_VIP_CL_DIL_0_SPAN == 256
+#define VIP_DIL_B
+#elif ALT_VIP_CL_DIL_0_SPAN == 128
+#define VIP_DIL_A
+#else
+#error VIP Deinterlacer II: unexpected run-time control address span
+#endif
+
 #ifndef DEBUG
 #define OS_PRINTF(...)
 #define ErrorF(...)

--- a/sw_common/sys_controller/inc/avconfig.h
+++ b/sw_common/sys_controller/inc/avconfig.h
@@ -152,8 +152,14 @@ typedef struct {
     uint8_t scl_framelock;
     uint8_t scl_aspect;
     uint8_t scl_alg;
-    uint8_t scl_dil_alg;
     uint8_t scl_dil_motion_shift;
+#ifndef VIP_DIL_B
+    uint8_t scl_dil_alg;
+#else
+    uint8_t scl_dil_motion_scale;
+    uint8_t scl_dil_cadence_detect_enable;
+    uint8_t scl_dil_visualize_motion;
+#endif
     uint8_t sm_scl_240p_288p;
     uint8_t sm_scl_480i_576i;
     uint8_t sm_scl_480p;

--- a/sw_common/sys_controller/src/avconfig.c
+++ b/sw_common/sys_controller/src/avconfig.c
@@ -46,8 +46,14 @@ const avconfig_t tc_default = {
 #ifdef VIP
     .scl_out_mode = 4,
     .scl_alg = 1,
-    .scl_dil_alg = 2,
     .scl_dil_motion_shift = 3,
+#ifndef VIP_DIL_B
+    .scl_dil_alg = 2,
+#else
+    .scl_dil_motion_scale = 125,
+    .scl_dil_cadence_detect_enable = 0,
+    .scl_dil_visualize_motion = 0,
+#endif
     .sm_scl_480p = 1,
 #endif
 #ifndef DExx_FW
@@ -106,8 +112,14 @@ status_t update_avconfig() {
         (tc.ypbpr_cs != cc.ypbpr_cs)
 #ifdef VIP
         || (tc.scl_alg != cc.scl_alg) ||
-        (tc.scl_dil_alg != cc.scl_dil_alg) ||
         (tc.scl_dil_motion_shift != cc.scl_dil_motion_shift)
+#ifndef VIP_DIL_B
+        || (tc.scl_dil_alg != cc.scl_dil_alg)
+#else
+        || (tc.scl_dil_motion_scale != cc.scl_dil_motion_scale) ||
+        (tc.scl_dil_cadence_detect_enable != cc.scl_dil_cadence_detect_enable) ||
+        (tc.scl_dil_visualize_motion != cc.scl_dil_visualize_motion)
+#endif
 #endif
        )
         status = (status < SC_CONFIG_CHANGE) ? SC_CONFIG_CHANGE : status;

--- a/sw_common/sys_controller/src/menu.c
+++ b/sw_common/sys_controller/src/menu.c
@@ -104,10 +104,12 @@ static const char *scl_out_mode_desc[] = { "720x480 (60Hz)", "720x576 (50Hz)", "
 static const char *scl_framelock_desc[] = { "On", "On (2x Hz)", "Off (closest Hz)", "Off (50Hz)", "Off (60Hz)", "Off (100Hz)", "Off (120Hz)" };
 static const char *scl_aspect_desc[] = { "4:3", "16:9", "8:7", "1:1 source PAR", "Full" };
 static const char *scl_alg_desc[] = { "Nearest", "Lanczos3" };
+#ifndef VIP_DIL_B
 #ifdef DEBUG
 static const char *scl_dil_alg_desc[] = { "Bob", "Weave", "Motion adaptive", "Visualize motion" };
 #else
 static const char *scl_dil_alg_desc[] = { "Bob", "Weave", "Motion adaptive" };
+#endif
 #endif
 static const char *sm_scl_240p_288p_desc[] = { "Generic", "SNES 256col", "SNES 512col", "MD 256col", "MD 320col", "PSX 256col", "PSX 320col", "PSX 384col", "PSX 512col", "PSX 640col", "N64 320col", "N64 640col" };
 static const char *sm_scl_480i_576i_desc[] = { "Generic", "DTV 480i/576i" };
@@ -246,8 +248,17 @@ MENU(menu_scaler, P99_PROTECT({
     { "Framelock",                              OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_framelock,   OPT_WRAP, SETTING_ITEM(scl_framelock_desc) } } },
     { "Aspect ratio",                           OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_aspect,      OPT_WRAP, SETTING_ITEM(scl_aspect_desc) } } },
     { "Scaling algorithm",                      OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_alg,         OPT_WRAP, SETTING_ITEM(scl_alg_desc) } } },
+#ifndef VIP_DIL_B
     { "Deinterlace mode",                       OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_dil_alg,     OPT_WRAP, SETTING_ITEM(scl_dil_alg_desc) } } },
+#endif
     { "Motion shift",                           OPT_AVCONFIG_NUMVALUE, { .num = { &tc.scl_dil_motion_shift,     OPT_NOWRAP, 0, 7, value_disp } } },
+#ifdef VIP_DIL_B
+    { "Motion scale",                           OPT_AVCONFIG_NUMVALUE, { .num = { &tc.scl_dil_motion_scale,     OPT_NOWRAP, 0, 255, value_disp } } },
+    { "Cadence detection",                      OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_dil_cadence_detect_enable,     OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
+#ifdef DEBUG
+    { "Visualize motion",                       OPT_AVCONFIG_SELECTION, { .sel = { &tc.scl_dil_visualize_motion,     OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
+#endif
+#endif
     { LNG("240p/288p mode","240p/288pﾓｰﾄﾞ"),    OPT_AVCONFIG_SELECTION, { .sel = { &tc.sm_scl_240p_288p, OPT_WRAP, SETTING_ITEM(sm_scl_240p_288p_desc) } } },
     { LNG("480i/576i mode","480i/576iﾓｰﾄﾞ"),    OPT_AVCONFIG_SELECTION, { .sel = { &tc.sm_scl_480i_576i, OPT_WRAP, SETTING_ITEM(sm_scl_480i_576i_desc) } } },
     { LNG("480p mode","480pﾓｰﾄﾞ"),              OPT_AVCONFIG_SELECTION, { .sel = { &tc.sm_scl_480p,      OPT_WRAP, SETTING_ITEM(sm_scl_480p_desc) } } },

--- a/sw_common/sys_controller/src/sys_controller.c
+++ b/sw_common/sys_controller/src/sys_controller.c
@@ -174,10 +174,22 @@ typedef struct {
     uint32_t ctrl;
     uint32_t status;
     uint32_t rsv;
+#ifndef VIP_DIL_B
     uint32_t unused[11];
     uint32_t motion_shift;
     uint32_t unused2;
     uint32_t mode;
+#else
+    uint32_t cadence_detected;
+    uint32_t unused[8];
+    uint32_t cadence_detect_enable;
+    uint32_t unused2[12];
+    uint32_t motion_shift;
+    uint32_t unused3;
+    uint32_t visualize_motion;
+    uint32_t rsv2[2];
+    uint32_t motion_scale;
+#endif
 } vip_dli_ii_regs;
 
 typedef struct {
@@ -323,6 +335,7 @@ void update_sc_config(mode_data_t *vm_in, mode_data_t *vm_out, vm_proc_config_t 
     vip_fb->ctrl = vip_enable;
     vip_cvo->ctrl = vip_enable;
 
+#ifndef VIP_DIL_B
     if (avconfig->scl_dil_alg == 0) {
         vip_dli->mode = (1<<1);
     } else if (avconfig->scl_dil_alg == 1) {
@@ -332,6 +345,11 @@ void update_sc_config(mode_data_t *vm_in, mode_data_t *vm_out, vm_proc_config_t 
     } else {
         vip_dli->mode = 0;
     }
+#else
+    vip_dli->motion_scale = avconfig->scl_dil_motion_scale;
+    vip_dli->cadence_detect_enable = avconfig->scl_dil_cadence_detect_enable;
+    vip_dli->visualize_motion = avconfig->scl_dil_visualize_motion;
+#endif
 
     vip_dli->motion_shift = avconfig->scl_dil_motion_shift;
 


### PR DESCRIPTION
While using register set B doesn't seem worthwhile for games [[1]](https://shmups.system11.org/viewtopic.php?p=1452093#p1452093), the situation might well be different for movie content, which further testing could clarify. This is to lay a foundation for that, and to serve reproducibility of the findings given by [1].